### PR TITLE
Support OT 2.0

### DIFF
--- a/examples/dsl.py
+++ b/examples/dsl.py
@@ -13,9 +13,7 @@ if __name__ == '__main__':
     client = Elasticsearch('127.0.0.1',
                            transport_class=elasticsearch_opentracing.TracingTransport)
 
-    with tracer.start_span('main span') as main_span:
-        elasticsearch_opentracing.set_active_span(main_span)
-
+    with tracer.start_active_span('main span') as main_scope:
         s = Search(using=client, index='test-index') \
             .filter('term', author='linus') \
             .query('match', text='git')

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,11 @@ setup(
     platforms='any',
     install_requires=[
         'elasticsearch',
-        'opentracing>=1.1,<1.2'
+        'opentracing>=2.0,<2.1'
+    ],
+    tests_require=[
+        'elasticsearch-dsl>=5.1',
+        'mock'
     ],
     classifiers=[
         'Intended Audience :: Developers',

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1,17 +1,16 @@
-import datetime
+from distutils.version import LooseVersion
 import unittest
-import threading
-import time
 
-from elasticsearch import Elasticsearch
-from elasticsearch_dsl import Search, Q, DocType, Integer, Keyword, Text
+from opentracing.mocktracer import MockTracer
+
+from elasticsearch_dsl import Search, DocType, Keyword, Text, VERSION
 from elasticsearch_dsl.connections import connections
 from elasticsearch_dsl.response import Response
-from elasticsearch_opentracing import TracingTransport, init_tracing, \
-        enable_tracing, disable_tracing, set_active_span, clear_active_span, \
-        get_active_span, _clear_tracing_state
+from elasticsearch_opentracing import TracingTransport, init_tracing, _clear_tracing_state
 from mock import patch
-from .dummies import *
+
+elasticsearch_dsl_version = LooseVersion('.'.join(str(i) for i in VERSION))
+
 
 class Article(DocType):
     title = Text(analyzer='snowball', fields={'raw': Keyword()})
@@ -19,16 +18,24 @@ class Article(DocType):
 
     class Meta:
         index = 'test-index'
+        if elasticsearch_dsl_version >= LooseVersion('6.0.0'):
+            doc_type = 'article'
+
+    if elasticsearch_dsl_version >= LooseVersion('6.2.0'):
+        class Index:
+            name = 'test-index'
+
 
 @patch('elasticsearch.Transport.perform_request')
 class TestTracing(unittest.TestCase):
     def setUp(self):
-        self.tracer = DummyTracer()
+        self.tracer = MockTracer()
         connections.create_connection(hosts=['127.0.0.1'],
                                       transport_class=TracingTransport)
 
     def tearDown(self):
         _clear_tracing_state()
+        self.tracer.reset()
 
     def test_search(self, mock_perform_req):
         init_tracing(self.tracer)
@@ -39,11 +46,12 @@ class TestTracing(unittest.TestCase):
             .filter('term', author='testing')
         res = s.execute()
 
+        spans = self.tracer.finished_spans()
+        self.assertEqual(1, len(spans))
+        span = spans[0]
         self.assertTrue(isinstance(res, Response))
-        self.assertEqual(1, len(self.tracer.spans))
-        self.assertEqual(self.tracer.spans[0].operation_name, 'Elasticsearch/test-index/_search')
-        self.assertEqual(self.tracer.spans[0].is_finished, True)
-        self.assertEqual(self.tracer.spans[0].tags, {
+        self.assertEqual(span.operation_name, 'Elasticsearch/test-index/_search')
+        self.assertEqual(span.tags, {
             'component': 'elasticsearch-py',
             'db.type': 'elasticsearch',
             'db.statement': {
@@ -59,17 +67,18 @@ class TestTracing(unittest.TestCase):
 
         Article.init()
 
-        self.assertEqual(2, len(self.tracer.spans))
-        self.assertEqual(map(lambda x: x.operation_name, self.tracer.spans), [
-            'Elasticsearch/test-index',
-            'Elasticsearch/test-index/_mapping/article'
-        ])
-        self.assertTrue(all(map(lambda x: x.is_finished, self.tracer.spans)))
+        spans = self.tracer.finished_spans()
+
+        expected_operations = ['Elasticsearch/test-index', 'Elasticsearch/test-index/_mapping/article']
+        if elasticsearch_dsl_version >= LooseVersion('6.2.0'):
+            expected_operations.insert(1, 'Elasticsearch/test-index/_settings')
+
+        self.assertEqual([s.operation_name for s in spans], expected_operations)
 
     def test_index(self, mock_perform_req):
         init_tracing(self.tracer)
 
-        mock_perform_req.return_value = {'created': True}
+        mock_perform_req.return_value = {'created': True, 'result': 'created'}
 
         article = Article(
             meta={'id': 2},
@@ -78,11 +87,12 @@ class TestTracing(unittest.TestCase):
         )
         res = article.save()
 
+        spans = self.tracer.finished_spans()
         self.assertTrue(res)
-        self.assertEqual(1, len(self.tracer.spans))
-        self.assertEqual(self.tracer.spans[0].operation_name, 'Elasticsearch/test-index/article/2')
-        self.assertEqual(self.tracer.spans[0].is_finished, True)
-        self.assertEqual(self.tracer.spans[0].tags, {
+        self.assertEqual(1, len(spans))
+        span = spans[0]
+        self.assertEqual(span.operation_name, 'Elasticsearch/test-index/article/2')
+        self.assertEqual(span.tags, {
             'component': 'elasticsearch-py',
             'db.type': 'elasticsearch',
             'db.statement': {


### PR DESCRIPTION
These changes adopt the 2.0 api and MockTracer.  Also included are some dsl test updates to work with newer library versions.